### PR TITLE
Use phabricator API tokens instead of certs and users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,35 +1,26 @@
 {
   "name": "hubot-phabricator",
   "description": "A hubot script to expand references to Phabricator objects",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": "David Lynch <kemayo@gmail.com>",
   "license": "MIT",
-
   "keywords": [
     "hubot",
     "hubot-scripts",
     "phabricator"
   ],
-
   "repository": {
     "type": "git",
     "url": "git://github.com/kemayo/hubot-phabricator.git"
   },
-
   "bugs": {
     "url": "https://github.com/kemayo/hubot-phabricator/issues"
   },
-
   "dependencies": {
-    "coffee-script": "~1.6",
-    "canduit": "~1.0.0"
+    "canduit": "^1.1.2",
+    "coffee-script": "~1.6"
   },
-
-  "devDependencies": {
-  },
-
+  "devDependencies": {},
   "main": "index.coffee",
-
-  "scripts": {
-  }
+  "scripts": {}
 }

--- a/src/phabricator.coffee
+++ b/src/phabricator.coffee
@@ -2,12 +2,11 @@
 #   Auto-reply with descriptions and links to phabricator objects
 #
 # Dependencies:
-#   "canduit": "!1.0.0"
+#   "canduit": "^1.1.2"
 #
 # Configuration:
-#   HUBOT_PHABRICATOR_USER=username
 #   HUBOT_PHABRICATOR_API=api-uri
-#   HUBOT_PHABRICATOR_CERT=certificate
+#   HUBOT_PHABRICATOR_API_TOKEN=api-xxxxxx
 #   HUBOT_PHABRICATOR_IGNORE=[T1000,D999,etc]
 #
 # Commands:
@@ -20,9 +19,8 @@ createCanduit = require('canduit')
 
 module.exports = (robot) ->
   config = {
-    user: process.env.HUBOT_PHABRICATOR_USER
     api: process.env.HUBOT_PHABRICATOR_API
-    cert: process.env.HUBOT_PHABRICATOR_CERT
+    token: process.env.HUBOT_PHABRICATOR_API_TOKEN
     # logger: console
   }
   conduit = createCanduit config,


### PR DESCRIPTION
- upgrade canduit version that supports using phabricator API tokens instead of users and certs
- update env variables to add `HUBOT_PHABRICATOR_API_TOKEN` and remove user/cert variables
- version bump
